### PR TITLE
Fail if returned name or scopes are different than requested in api-key creation

### DIFF
--- a/sendgrid/resource_api_key.go
+++ b/sendgrid/resource_api_key.go
@@ -247,9 +247,9 @@ func waitForAPIKey(d *schema.ResourceData, m interface{}) error {
 			} else if key == nil {
 				return nil, statusWaiting, nil
 			} else if key.Name != name {
-				return nil, statusWaiting, nil
+				return nil, "", fmt.Errorf("name in created api-key is different from name: want=%s, got=%s", name, key.Name)
 			} else if !sliceContentsAreEqual(key.Scopes, scopes) {
-				return nil, statusWaiting, nil
+				return nil, "", fmt.Errorf("scopes in created api-key are different from desired scopes: want=%+v, got=%+v", scopes, key.Scopes)
 			}
 
 			return key, statusDone, nil


### PR DESCRIPTION
Solves #2.

Sendgrid API adds additional scopes sometimes. Previously, if that was the case, the provider kept retrying, causing a timeout eventually.

This makes it fail and returns the details of the error, so the user can adjust the scopes in their terraform definition and make it work.

It handles differences in the name of the api-key in the same way.