### PR TITLE
Make released binary be statically linked

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -29,7 +29,7 @@ do
         output_name+='.exe'
     fi
 
-    env GOOS=$GOOS GOARCH=$GOARCH go build -v -o $output_name
+    env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -v -o $output_name
     if [ $? -ne 0 ]; then
         echo 'An error has occurred! Aborting the script execution...'
         exit 1


### PR DESCRIPTION
This disables CGO in the Golang compiler, so the binary is statically linked instead of linked to system libraries.

This solves a problem when using the provider inside some very limited OSs that do not include some of those common libraries.